### PR TITLE
Add .env.example file and document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Network configuration
+VITE_APP_NETWORK=testnet
+
+# Smart contract module address
+VITE_MODULE_ADDRESS=your_module_address_here
+
+# Aptos API key (if required)
+VITE_APTOS_API_KEY=your_aptos_api_key_here
+
+# Publisher account details
+VITE_MODULE_PUBLISHER_ACCOUNT_ADDRESS=your_account_address_here
+VITE_MODULE_PUBLISHER_ACCOUNT_PRIVATE_KEY=your_private_key_here

--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ By turning invoices into on-chain assets, we enable:
 
 ## 🛡 License
 This project is licensed under the **Apache License 2.0**.A tokenizing Aptos dapp.
+
+## 🔐 Environment Variables (For Local Development)
+
+To run this project locally, create a `.env` file in the root directory.
+
+You can copy from the example file:
+
+```bash
+cp .env.example .env


### PR DESCRIPTION
This PR adds a .env.example file with placeholder values 
and documents required environment variables in README.

- Added .env.example
- Documented all environment variables
- Ensured no sensitive data is committed

Fixes #9
